### PR TITLE
Some fixes for Ubuntu

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,6 @@
 ---
 
-- name: Restart gdm
-  service:
-    name: 'display-manager'
-    state: 'restarted'
-  when: dm__restart_on_configuration_change | bool
-
-- name: Restart lightdm
+- name: Restart display-manager
   service:
     name: 'display-manager'
     state: 'restarted'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,12 +2,12 @@
 
 - name: Restart gdm
   service:
-    name: 'gdm3'
+    name: 'display-manager'
     state: 'restarted'
   when: dm__restart_on_configuration_change | bool
 
 - name: Restart lightdm
   service:
-    name: 'lightdm'
+    name: 'display-manager'
     state: 'restarted'
   when: dm__restart_on_configuration_change | bool

--- a/tasks/gdm.yml
+++ b/tasks/gdm.yml
@@ -25,7 +25,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Restart gdm' ]
+  notify: [ 'Restart display-manager' ]
 
 - name: Configure dconf defaults
   template:
@@ -34,4 +34,4 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Restart gdm' ]
+  notify: [ 'Restart display-manager' ]

--- a/tasks/lightdm.yml
+++ b/tasks/lightdm.yml
@@ -39,7 +39,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Restart lightdm' ]
+  notify: [ 'Restart display-manager' ]
 
 - name: Configure LightDM greeter
   template:
@@ -48,4 +48,4 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Restart lightdm' ]
+  notify: [ 'Restart display-manager' ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
     src: '/lib/systemd/system/{{ dm__package_map[dm__name] }}.service'
     dest: '/etc/systemd/system/display-manager.service'
     state: 'link'
-  when: (ansible_distribution|d("") == "Debian")
+  when: (ansible_os_family|d("") == "Debian")
 
 - name: Configure default session manager
   alternatives:


### PR DESCRIPTION
- Fix: Systemd is not configured in Ubuntu.
- Fix: The display-manager is not restarted when `dm__restart_on_configuration_change` is `True`.