### PR TITLE
Add daemon-reload when service is changed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Reload systemd services
+  systemd:
+    daemon_reload: yes
+
 - name: Restart display-manager
   service:
     name: 'display-manager'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
     - '{{ dm__package_map[dm__name] }}'
     - '{{ dm__lightdm_packages if (dm__name == "lightdm") else [] }}'
     - '{{ dm__gdm_packages if (dm__name == "gdm") else [] }}'
+  notify: [ 'Reload systemd services', 'Restart display-manager' ]
   tags: [ 'role::dm:pkg' ]
 
 - import_tasks: 'gdm.yml'
@@ -51,6 +52,7 @@
     src: '/lib/systemd/system/{{ dm__package_map[dm__name] }}.service'
     dest: '/etc/systemd/system/display-manager.service'
     state: 'link'
+  notify: [ 'Reload systemd services', 'Restart display-manager' ]
   when: (ansible_os_family|d("") == "Debian")
 
 - name: Configure default session manager


### PR DESCRIPTION
This fix resolves the issue where restarting display-manager fails when changing dm.