### PR TITLE
Use FQCN for dpkg_divert

### DIFF
--- a/tasks/lightdm.yml
+++ b/tasks/lightdm.yml
@@ -16,7 +16,7 @@
     mode: '0755'
 
 - name: Divert LightDM configuration
-  dpkg_divert:
+  community.general.dpkg_divert:
     path: '/etc/lightdm/lightdm-gtk-greeter.conf'
     state: 'present'
   when: not (dm__testing_mode|d(False) | bool)


### PR DESCRIPTION
I got a following error:

> ERROR! couldn't resolve module/action 'dpkg_divert'. This often indicates a misspelling, missing collection, or incorrect module path.

I solved it using FQCN.

**Versions**
- Ubuntu 20.04
- ansible [core 2.12.2]
- community.general 4.5.0